### PR TITLE
Clear cart after successful booking and fix modal overflow

### DIFF
--- a/src/components/BookingFlow.tsx
+++ b/src/components/BookingFlow.tsx
@@ -266,6 +266,16 @@ const BookingFlow: React.FC<BookingFlowProps> = ({
         console.log("✅ Booking created successfully:", data);
         // Store the completed booking data
         setCompletedBooking(data);
+
+        // Clear cart after successful booking
+        localStorage.removeItem("laundry_cart");
+        localStorage.removeItem("mobile_service_cart");
+        localStorage.removeItem("laundry_booking_form");
+
+        // Dispatch cart clear event
+        const clearCartEvent = new CustomEvent("clearCart");
+        window.dispatchEvent(clearCartEvent);
+
         // Close confirmation modal and show success alert
         setShowConfirmation(false);
         setShowBookingSuccess(true);
@@ -714,6 +724,13 @@ const BookingFlow: React.FC<BookingFlowProps> = ({
         isVisible={showBookingSuccess}
         onClose={() => {
           setShowBookingSuccess(false);
+
+          // Ensure cart is cleared on success alert close as well
+          localStorage.removeItem("laundry_cart");
+          localStorage.removeItem("mobile_service_cart");
+          const clearCartEvent = new CustomEvent("clearCart");
+          window.dispatchEvent(clearCartEvent);
+
           if (onBookingComplete) {
             onBookingComplete();
           }

--- a/src/components/BookingFlow.tsx
+++ b/src/components/BookingFlow.tsx
@@ -270,7 +270,10 @@ const BookingFlow: React.FC<BookingFlowProps> = ({
         // Clear cart after successful booking
         localStorage.removeItem("laundry_cart");
         localStorage.removeItem("mobile_service_cart");
+        localStorage.removeItem("service_cart");
+        localStorage.removeItem("cleancare_cart");
         localStorage.removeItem("laundry_booking_form");
+        localStorage.removeItem("cleancare_booking_form");
 
         // Dispatch cart clear event
         const clearCartEvent = new CustomEvent("clearCart");
@@ -728,6 +731,8 @@ const BookingFlow: React.FC<BookingFlowProps> = ({
           // Ensure cart is cleared on success alert close as well
           localStorage.removeItem("laundry_cart");
           localStorage.removeItem("mobile_service_cart");
+          localStorage.removeItem("service_cart");
+          localStorage.removeItem("cleancare_cart");
           const clearCartEvent = new CustomEvent("clearCart");
           window.dispatchEvent(clearCartEvent);
 

--- a/src/components/LaundryCart.tsx
+++ b/src/components/LaundryCart.tsx
@@ -113,6 +113,9 @@ const LaundryCart: React.FC<LaundryCartProps> = ({
       console.log("🧹 Received cart clear event");
       setCart({});
       localStorage.removeItem("laundry_cart");
+      localStorage.removeItem("mobile_service_cart");
+      localStorage.removeItem("service_cart");
+      localStorage.removeItem("cleancare_cart");
     };
 
     const handleLogout = () => {
@@ -655,7 +658,7 @@ Confirm this booking?`;
             ),
           );
         } catch (checkoutError) {
-          console.error("💥 Checkout process failed:", checkoutError);
+          console.error("��� Checkout process failed:", checkoutError);
           addNotification(
             createErrorNotification(
               "Checkout Failed",

--- a/src/components/MobileBookingFlow.tsx
+++ b/src/components/MobileBookingFlow.tsx
@@ -217,7 +217,21 @@ const MobileBookingFlow: React.FC<MobileBookingFlowProps> = ({
       if (bookingError) {
         setError(bookingError.message || "Failed to create booking");
       } else {
+        // Clear cart after successful booking
+        localStorage.removeItem("laundry_cart");
+        localStorage.removeItem("mobile_service_cart");
+        localStorage.removeItem("laundry_booking_form");
+
+        // Dispatch cart clear event
+        const clearCartEvent = new CustomEvent("clearCart");
+        window.dispatchEvent(clearCartEvent);
+
         setShowConfirmation(true);
+
+        // Call booking complete callback
+        if (onBookingComplete) {
+          onBookingComplete();
+        }
       }
     } catch (error: any) {
       setError(

--- a/src/components/MobileBookingFlow.tsx
+++ b/src/components/MobileBookingFlow.tsx
@@ -220,7 +220,10 @@ const MobileBookingFlow: React.FC<MobileBookingFlowProps> = ({
         // Clear cart after successful booking
         localStorage.removeItem("laundry_cart");
         localStorage.removeItem("mobile_service_cart");
+        localStorage.removeItem("service_cart");
+        localStorage.removeItem("cleancare_cart");
         localStorage.removeItem("laundry_booking_form");
+        localStorage.removeItem("cleancare_booking_form");
 
         // Dispatch cart clear event
         const clearCartEvent = new CustomEvent("clearCart");

--- a/src/components/MobileServiceCategories.tsx
+++ b/src/components/MobileServiceCategories.tsx
@@ -51,6 +51,9 @@ const MobileServiceCategories: React.FC<ServiceCategoriesProps> = ({
       console.log("🧹 MobileServiceCategories: Received cart clear event");
       setCart([]);
       localStorage.removeItem("mobile_service_cart");
+      localStorage.removeItem("laundry_cart");
+      localStorage.removeItem("service_cart");
+      localStorage.removeItem("cleancare_cart");
     };
 
     window.addEventListener("clearCart", handleClearCart);

--- a/src/components/ProfileSettingsModal.tsx
+++ b/src/components/ProfileSettingsModal.tsx
@@ -100,7 +100,7 @@ const ProfileSettingsModal: React.FC<ProfileSettingsModalProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-md w-[95vw] mx-4 sm:mx-auto border-0 shadow-2xl rounded-3xl overflow-hidden bg-gradient-to-br from-white via-gray-50/50 to-green-50/30 animate-in zoom-in-95 duration-300 fade-in-0">
+      <DialogContent className="sm:max-w-md w-[95vw] mx-4 sm:mx-auto border-0 shadow-2xl rounded-3xl overflow-hidden bg-gradient-to-br from-white via-gray-50/50 to-green-50/30 animate-in zoom-in-95 duration-300 fade-in-0 max-h-[90vh] overflow-y-auto">
         <DialogHeader className="pb-2">
           <DialogTitle className="flex items-center justify-between text-xl font-bold bg-gradient-to-r from-green-600 to-emerald-600 bg-clip-text text-transparent">
             Profile Settings
@@ -118,7 +118,7 @@ const ProfileSettingsModal: React.FC<ProfileSettingsModalProps> = ({
           </DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-6 p-1">
+        <div className="space-y-6 p-1 max-h-[calc(90vh-120px)] overflow-y-auto">
           {/* Profile Picture */}
           <div className="flex justify-center">
             <div className="relative">

--- a/src/components/ResponsiveLaundryHome.tsx
+++ b/src/components/ResponsiveLaundryHome.tsx
@@ -198,6 +198,9 @@ const ResponsiveLaundryHome: React.FC<ResponsiveLaundryHomeProps> = ({
       console.log("🧹 ResponsiveLaundryHome: Received cart clear event");
       setCart({});
       localStorage.removeItem("laundry_cart");
+      localStorage.removeItem("mobile_service_cart");
+      localStorage.removeItem("service_cart");
+      localStorage.removeItem("cleancare_cart");
     };
 
     window.addEventListener("clearCart", handleClearCart);

--- a/src/components/ServiceCategories.tsx
+++ b/src/components/ServiceCategories.tsx
@@ -53,6 +53,9 @@ const ServiceCategories: React.FC<ServiceCategoriesProps> = ({
       console.log("🧹 ServiceCategories: Received cart clear event");
       setCart([]);
       localStorage.removeItem("service_cart");
+      localStorage.removeItem("laundry_cart");
+      localStorage.removeItem("mobile_service_cart");
+      localStorage.removeItem("cleancare_cart");
     };
 
     window.addEventListener("clearCart", handleClearCart);

--- a/src/components/ZomatoStyleCart.tsx
+++ b/src/components/ZomatoStyleCart.tsx
@@ -108,6 +108,9 @@ const ZomatoStyleCart: React.FC<ZomatoStyleCartProps> = ({
     const handleClearCart = () => {
       setCart({});
       localStorage.removeItem("laundry_cart");
+      localStorage.removeItem("mobile_service_cart");
+      localStorage.removeItem("service_cart");
+      localStorage.removeItem("cleancare_cart");
     };
 
     window.addEventListener("clearCart", handleClearCart);
@@ -576,7 +579,7 @@ const ZomatoStyleCart: React.FC<ZomatoStyleCartProps> = ({
           <CardContent className="p-4">
             <div className="flex items-center gap-2 mb-4">
               <CreditCard className="h-4 w-4 text-gray-600" />
-              <span className="font-medium">Total Bill ₹{getSubtotal()}</span>
+              <span className="font-medium">Total Bill ��{getSubtotal()}</span>
               <span className="text-sm text-green-600 font-medium">
                 ₹{getTotal()}
               </span>

--- a/src/pages/LaundryIndex.tsx
+++ b/src/pages/LaundryIndex.tsx
@@ -672,6 +672,9 @@ const LaundryIndex = () => {
           // Store booking data for confirmation screen
           const confirmationData = {
             bookingId: `local_${Date.now()}`,
+            custom_order_id:
+              localResult.data?.custom_order_id ||
+              `CC${Date.now().toString().slice(-6)}`, // Add custom_order_id for local bookings
             services: detailedServices, // Use detailed services with quantities
             totalAmount: cartData.totalAmount,
             pickupDate: cartData.pickupDate,

--- a/src/pages/LaundryIndex.tsx
+++ b/src/pages/LaundryIndex.tsx
@@ -620,7 +620,11 @@ const LaundryIndex = () => {
 
         // Clear cart and form data
         localStorage.removeItem("laundry_cart");
+        localStorage.removeItem("mobile_service_cart");
+        localStorage.removeItem("service_cart");
+        localStorage.removeItem("cleancare_cart");
         localStorage.removeItem("laundry_booking_form");
+        localStorage.removeItem("cleancare_booking_form");
         localStorage.removeItem("user_bookings"); // Clear cached bookings
 
         // Clear any cached cart state
@@ -690,6 +694,9 @@ const LaundryIndex = () => {
 
           // Clear cart
           localStorage.removeItem("laundry_cart");
+          localStorage.removeItem("mobile_service_cart");
+          localStorage.removeItem("service_cart");
+          localStorage.removeItem("cleancare_cart");
 
           // Show booking confirmation screen
           setCurrentView("booking-confirmed");


### PR DESCRIPTION
This pull request includes two main changes:

**Cart Clearing:**
- Added cart clearing functionality after successful booking in both BookingFlow and MobileBookingFlow components
- Removes laundry_cart, mobile_service_cart, and laundry_booking_form from localStorage
- Dispatches clearCart custom event to notify other components
- Ensures cart is cleared both on booking success and when success alert is closed

**Modal Overflow Fix:**
- Added max-height and overflow-y-auto to ProfileSettingsModal
- Set modal content to max-h-[90vh] with scrollable overflow
- Added scrollable container for modal content with max-h-[calc(90vh-120px)]

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/f48dec9b96cc4e88a9666c29f0633d2f/mystic-studio)

👀 [Preview Link](https://f48dec9b96cc4e88a9666c29f0633d2f-mystic-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>f48dec9b96cc4e88a9666c29f0633d2f</projectId>-->
<!--<branchName>mystic-studio</branchName>-->