### PR TITLE
Remove fallback logic for delivery date and time

### DIFF
--- a/backend/routes/bookings.js
+++ b/backend/routes/bookings.js
@@ -507,8 +507,8 @@ router.post("/", async (req, res) => {
       scheduled_date,
       scheduled_time,
 
-            delivery_date: delivery_date || scheduled_date, // Use delivery date from cart or fallback to pickup date
-      delivery_time: delivery_time || scheduled_time, // Use delivery time from cart or fallback to pickup time
+            delivery_date: delivery_date, // Use delivery date from request
+      delivery_time: delivery_time, // Use delivery time from request
       provider_name,
 
       address: sanitizedAddress, // Use sanitized string address


### PR DESCRIPTION
Remove fallback logic for delivery_date and delivery_time fields in booking creation.

Previously, delivery_date would fallback to scheduled_date if not provided, and delivery_time would fallback to scheduled_time if not provided.

Now delivery_date and delivery_time are used directly from the request without any fallback values.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/dc2a75d2dc2d45c58845f7c7b1e7665e/neon-haven)

👀 [Preview Link](https://dc2a75d2dc2d45c58845f7c7b1e7665e-neon-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>dc2a75d2dc2d45c58845f7c7b1e7665e</projectId>-->
<!--<branchName>neon-haven</branchName>-->