### PR TITLE
Add delivery date and time fields to LaundryIndex

### DIFF
--- a/src/pages/LaundryIndex.tsx
+++ b/src/pages/LaundryIndex.tsx
@@ -548,6 +548,8 @@ const LaundryIndex = () => {
         services: servicesArray,
         scheduled_date: cartData.pickupDate,
         scheduled_time: cartData.pickupTime,
+        delivery_date: cartData.deliveryDate,
+        delivery_time: cartData.deliveryTime,
         provider_name: "CleanCare Pro",
         address:
           typeof cartData.address === "string"


### PR DESCRIPTION
Add delivery_date and delivery_time fields to the LaundryIndex component.

The changes include:
- Added delivery_date field mapped to cartData.deliveryDate
- Added delivery_time field mapped to cartData.deliveryTime

These fields are added alongside the existing scheduled_date and scheduled_time fields in the component's data structure.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/54b755fa725a4cd9b8160f569d2725a6/orbit-space)

👀 [Preview Link](https://54b755fa725a4cd9b8160f569d2725a6-orbit-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>54b755fa725a4cd9b8160f569d2725a6</projectId>-->
<!--<branchName>orbit-space</branchName>-->