### PR TITLE
Fix item prices in booking database with correct pricing

### DIFF
--- a/backend/data/laundryServices.js
+++ b/backend/data/laundryServices.js
@@ -1,0 +1,238 @@
+// Laundry services data for backend price lookup
+const laundryServices = [
+  // Laundry Services
+  {
+    id: "laundry-fold",
+    name: "Laundry and Fold",
+    price: 70,
+    unit: "KG",
+    category: "laundry",
+  },
+  {
+    id: "laundry-iron",
+    name: "Laundry and Iron",
+    price: 120,
+    unit: "KG",
+    category: "laundry",
+  },
+
+  // Iron Services
+  {
+    id: "regular-iron",
+    name: "Regular Iron",
+    price: 20,
+    unit: "PC",
+    category: "iron",
+  },
+  {
+    id: "steam-press-suit",
+    name: "Men's Suit / Lehenga / Heavy Dresses",
+    price: 150,
+    unit: "SET",
+    category: "iron",
+  },
+  {
+    id: "steam-press-ladies-suit",
+    name: "Ladies Suit / Kurta & Pyjama / Saree",
+    price: 100,
+    unit: "SET",
+    category: "iron",
+  },
+  {
+    id: "steam-press-regular",
+    name: "Regular Items",
+    price: 40,
+    unit: "PC",
+    category: "iron",
+  },
+
+  // Men's Dry Clean
+  {
+    id: "dry-clean-mens-shirt",
+    name: "Men's Shirt/T-Shirt",
+    price: 100,
+    unit: "PC",
+    category: "mens-dry-clean",
+  },
+  {
+    id: "dry-clean-mens-trouser",
+    name: "Trouser/Jeans",
+    price: 120,
+    unit: "PC",
+    category: "mens-dry-clean",
+  },
+  {
+    id: "dry-clean-mens-coat",
+    name: "Coat",
+    price: 240,
+    unit: "PC",
+    category: "mens-dry-clean",
+  },
+  {
+    id: "dry-clean-mens-suit-2pc",
+    name: "Men's Suit 2 PC",
+    price: 360,
+    unit: "SET",
+    category: "mens-dry-clean",
+  },
+  {
+    id: "dry-clean-mens-suit-3pc",
+    name: "Men's Suit 3 PC",
+    price: 540,
+    unit: "SET",
+    category: "mens-dry-clean",
+  },
+  {
+    id: "dry-clean-kurta-pyjama",
+    name: "Kurta Pyjama (2 PC)",
+    price: 220,
+    unit: "SET",
+    category: "mens-dry-clean",
+  },
+  {
+    id: "dry-clean-achkan-sherwani",
+    name: "Achkan / Sherwani",
+    price: 300,
+    unit: "SET",
+    category: "mens-dry-clean",
+  },
+  {
+    id: "dry-clean-mens-kurta",
+    name: "Kurta",
+    price: 120,
+    unit: "PC",
+    category: "mens-dry-clean",
+  },
+
+  // Women's Dry Clean
+  {
+    id: "dry-clean-womens-kurta-kurti",
+    name: "Kurta / Kurti",
+    price: 120,
+    unit: "PC",
+    category: "womens-dry-clean",
+  },
+  {
+    id: "dry-clean-salwar-plazo",
+    name: "Salwar/Plazo/Dupatta",
+    price: 120,
+    unit: "PC",
+    category: "womens-dry-clean",
+  },
+  {
+    id: "dry-clean-saree-simple",
+    name: "Saree Simple/Silk",
+    price: 240,
+    unit: "PC",
+    category: "womens-dry-clean",
+  },
+  {
+    id: "dry-clean-saree-heavy",
+    name: "Saree (Heavy Work)",
+    price: 300,
+    unit: "PC",
+    category: "womens-dry-clean",
+  },
+  {
+    id: "dry-clean-blouse",
+    name: "Blouse",
+    price: 90,
+    unit: "PC",
+    category: "womens-dry-clean",
+  },
+  {
+    id: "dry-clean-dress",
+    name: "Dress",
+    price: 240,
+    unit: "PC",
+    category: "womens-dry-clean",
+  },
+  {
+    id: "dry-clean-top",
+    name: "Top",
+    price: 140,
+    unit: "PC",
+    category: "womens-dry-clean",
+  },
+  {
+    id: "dry-clean-skirt-heavy",
+    name: "Skirt (Heavy Work)",
+    price: 180,
+    unit: "PC",
+    category: "womens-dry-clean",
+  },
+  {
+    id: "dry-clean-lehenga-1pc",
+    name: "Lehenga 1 PC",
+    price: 400,
+    unit: "PC",
+    category: "womens-dry-clean",
+  },
+  {
+    id: "dry-clean-lehenga-2pc",
+    name: "Lehenga 2+ PC",
+    price: 600,
+    unit: "SET",
+    category: "womens-dry-clean",
+  },
+  {
+    id: "dry-clean-lehenga-heavy",
+    name: "Lehenga Heavy",
+    price: 700,
+    unit: "SET",
+    category: "womens-dry-clean",
+  },
+  {
+    id: "dry-clean-lehenga-bridal-luxury",
+    name: "Lehenga Bridal / Luxury",
+    price: 1000,
+    unit: "SET",
+    category: "womens-dry-clean",
+  },
+
+  // Woolen Dry Clean
+  {
+    id: "dry-clean-jacket",
+    name: "Jacket F/H Sleeves",
+    price: 240,
+    unit: "PC",
+    category: "woolen-dry-clean",
+  },
+  {
+    id: "dry-clean-sweater",
+    name: "Sweater / Sweat Shirt",
+    price: 180,
+    unit: "PC",
+    category: "woolen-dry-clean",
+  },
+  {
+    id: "dry-clean-long-coat",
+    name: "Long Coat",
+    price: 300,
+    unit: "PC",
+    category: "woolen-dry-clean",
+  },
+  {
+    id: "dry-clean-shawl",
+    name: "Shawl",
+    price: 180,
+    unit: "PC",
+    category: "woolen-dry-clean",
+  },
+  {
+    id: "dry-clean-pashmina",
+    name: "Pashmina",
+    price: 300,
+    unit: "PC",
+    category: "woolen-dry-clean",
+  },
+  {
+    id: "dry-clean-leather-jacket",
+    name: "Leather Jacket",
+    price: 480,
+    unit: "PC",
+    category: "woolen-dry-clean",
+  },
+];
+
+module.exports = laundryServices;


### PR DESCRIPTION
## Purpose
The user identified an issue where the booking database was incorrectly using a hardcoded price of 50 for all items instead of the actual service prices. They requested that the system use the correct prices for each laundry service item.

## Code changes
- **Added laundry services data file** (`backend/data/laundryServices.js`): Created comprehensive pricing data for all laundry services including:
  - Laundry and fold/iron services (70-120 per KG)
  - Iron services (20-150 per piece/set)
  - Men's dry cleaning (100-540 per piece/set)
  - Women's dry cleaning (90-1000 per piece/set)
  - Woolen dry cleaning (180-480 per piece)

- **Enhanced booking route logic** (`backend/routes/bookings.js`):
  - Added priority system for item pricing: first use provided `item_prices`, then lookup from services data
  - Implemented price lookup functionality that matches service names/IDs to actual prices
  - Added fallback logic that uses 50 as final default only when no price is found
  - Added console logging for price lookup debugging

This ensures accurate pricing in the booking database instead of the previous hardcoded 50 value.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/05ffdd031fb14388a118a4fb2989e6cc/orbit-field)

👀 [Preview Link](https://05ffdd031fb14388a118a4fb2989e6cc-orbit-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>05ffdd031fb14388a118a4fb2989e6cc</projectId>-->
<!--<branchName>orbit-field</branchName>-->