### PR TITLE
Fix modal z-index layering to prevent UI overlap issues

### DIFF
--- a/src/components/ProfileSettingsModal.tsx
+++ b/src/components/ProfileSettingsModal.tsx
@@ -110,7 +110,7 @@ const ProfileSettingsModal: React.FC<ProfileSettingsModalProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-md w-[95vw] mx-4 sm:mx-auto border-0 shadow-2xl rounded-3xl overflow-hidden bg-gradient-to-br from-white via-gray-50/50 to-green-50/30 animate-in zoom-in-95 duration-300 fade-in-0 max-h-[90vh] overflow-y-auto">
+      <DialogContent className="sm:max-w-md w-[95vw] mx-4 sm:mx-auto border-0 shadow-2xl rounded-3xl overflow-hidden bg-gradient-to-br from-white via-gray-50/50 to-green-50/30 animate-in zoom-in-95 duration-300 fade-in-0 max-h-[90vh] overflow-y-auto z-[70] modal-content">
         <DialogHeader className="pb-2">
           <DialogTitle className="flex items-center justify-between text-xl font-bold bg-gradient-to-r from-green-600 to-emerald-600 bg-clip-text text-transparent">
             Profile Settings

--- a/src/components/SavedAddressesModal.tsx
+++ b/src/components/SavedAddressesModal.tsx
@@ -189,7 +189,7 @@ const SavedAddressesModal: React.FC<SavedAddressesModalProps> = React.memo(
       try {
         console.log("🗑️ Deleting address with ID:", id);
 
-        console.log("🗑️ Deleting address with AddressService...");
+        console.log("����️ Deleting address with AddressService...");
         const addressService = AddressService.getInstance();
         const result = await addressService.deleteAddress(id);
 
@@ -243,8 +243,8 @@ const SavedAddressesModal: React.FC<SavedAddressesModalProps> = React.memo(
     if (!isOpen) return null;
 
     return (
-      <div className="fixed inset-0 bg-black bg-opacity-50 z-[60] flex items-end modal-overlay" style={{ paddingTop: '120px' }}>
-        <div className="w-full bg-white rounded-t-2xl h-full overflow-y-auto relative modal-content" style={{ maxHeight: 'calc(100vh - 120px)' }}>
+      <div className="fixed inset-0 bg-black bg-opacity-50 z-[70] flex items-center justify-center modal-overlay">
+        <div className="w-full max-w-lg bg-white rounded-lg h-[85vh] overflow-y-auto relative modal-content mx-4 my-8">
           {/* Header */}
           <div className="flex items-center justify-between p-4 border-b border-gray-100">
             <h2 className="text-lg font-semibold text-gray-900">

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-[71] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg modal-content",
         className
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -19,7 +19,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[70] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 modal-overlay",
       className
     )}
     {...props}

--- a/src/styles/mobile-sticky-search.css
+++ b/src/styles/mobile-sticky-search.css
@@ -39,6 +39,15 @@
     transition: opacity 0.2s ease;
   }
 
+  /* Ensure modal overlays are above sticky elements */
+  .modal-overlay {
+    z-index: 70 !important; /* Above sticky search (z-50) */
+  }
+
+  .modal-content {
+    z-index: 71 !important; /* Above modal overlay */
+  }
+
   /* Ensure scrollable content has proper spacing */
   .mobile-services-content {
     margin-top: 16px;

--- a/src/styles/mobile-sticky-search.css
+++ b/src/styles/mobile-sticky-search.css
@@ -14,22 +14,13 @@
     backdrop-filter: blur(8px);
   }
 
-  /* Modal z-index layers */
-  .modal-overlay {
-    z-index: 60 !important; /* Above sticky search (z-50) */
-  }
-
-  .modal-content {
-    z-index: 61 !important; /* Above modal overlay */
-  }
-
   /* Nested modal layers for stacked modals */
   .modal-overlay-nested {
-    z-index: 70 !important; /* Above other modals */
+    z-index: 80 !important; /* Above other modals */
   }
 
   .modal-content-nested {
-    z-index: 71 !important; /* Above nested modal overlay */
+    z-index: 81 !important; /* Above nested modal overlay */
   }
 
   /* Hide sticky search when modal is open */


### PR DESCRIPTION
## Purpose
Users reported UI overlap issues where the saved addresses modal was being overlapped by the search box and category elements. The conversation history indicates problems with modal layering and z-index conflicts that were preventing proper display of profile-related modals.

## Code changes
- **Increased z-index values** for modal components from z-50/z-60 to z-70/z-71 to ensure proper layering above sticky search elements
- **Updated SavedAddressesModal layout** from bottom-sheet style to centered modal with proper dimensions and spacing
- **Enhanced dialog component z-index** in ui/dialog.tsx to prevent overlap with other UI elements
- **Reorganized CSS z-index hierarchy** in mobile-sticky-search.css for better modal stacking order
- **Added modal-content and modal-overlay classes** for consistent styling across components

These changes ensure modals display properly above all other UI elements and prevent the reported overlap issues.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/05ffdd031fb14388a118a4fb2989e6cc/neon-verse)

👀 [Preview Link](https://05ffdd031fb14388a118a4fb2989e6cc-neon-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>05ffdd031fb14388a118a4fb2989e6cc</projectId>-->
<!--<branchName>neon-verse</branchName>-->