### PR TITLE
Update URLs to Railway deployment endpoints

### DIFF
--- a/backend/config/production.js
+++ b/backend/config/production.js
@@ -23,9 +23,9 @@ const config = {
   ALLOWED_ORIGINS: process.env.ALLOWED_ORIGINS
     ? process.env.ALLOWED_ORIGINS.split(",")
     : [
-        "https://testversion.onrender.com",
-        "https://cleancarepro-1-p2oc.onrender.com",
-        "https://laundrify-app-5su7.onrender.com",
+        "https://laundrify-up.up.railway.app",
+        "http://localhost:5173",
+        "http://localhost:3000",
       ],
 
   // SMS Service

--- a/public/sw.js
+++ b/public/sw.js
@@ -53,6 +53,7 @@ self.addEventListener("fetch", (event) => {
   // Don't interfere with API requests at all - let them pass through normally
   if (
     event.request.url.includes("/api/") ||
+    event.request.url.includes("railway.app") ||
     event.request.url.includes("onrender.com") ||
     event.request.url.includes("localhost:3001") ||
     event.request.url.includes("laundrify") ||

--- a/render.yaml
+++ b/render.yaml
@@ -14,7 +14,7 @@ services:
       - key: MONGODB_DATABASE
         value: cleancare_pro
       - key: ALLOWED_ORIGINS
-        value: https://cleancare-pro-frontend.onrender.com
+        value: https://laundrify-up.up.railway.app
 
   - type: web
     name: cleancare-pro-frontend

--- a/render.yaml
+++ b/render.yaml
@@ -24,11 +24,11 @@ services:
     envVars:
       - fromGroup: cleancare-secrets
       - key: VITE_API_BASE_URL
-        value: https://cleancare-pro-api.onrender.com/api
+        value: https://cleancare-pro-api-production-129e.up.railway.app/api
       - key: VITE_APP_NAME
-        value: CleanCare Pro
+        value: Laundrify
       - key: VITE_APP_URL
-        value: https://cleancare-pro-frontend.onrender.com
+        value: https://laundrify-up.up.railway.app
 
 envVarGroups:
   - name: cleancare-secrets

--- a/src/config/production-env.ts
+++ b/src/config/production-env.ts
@@ -3,9 +3,8 @@
  * Handles proper API URL detection for production deployment
  */
 
-// Define the correct production API URL - always point to the backend
-// For now using the same domain approach - you may need to update this to your actual backend URL
-export const PRODUCTION_API_URL = "https://laundrify-app-5su7.onrender.com/api";
+// Define the correct production API URL - Railway backend
+export const PRODUCTION_API_URL = "https://cleancare-pro-api-production-129e.up.railway.app/api";
 
 export const getProductionApiUrl = (): string => {
   // Check if we're in production based on hostname

--- a/src/config/production.ts
+++ b/src/config/production.ts
@@ -9,7 +9,7 @@ export const PRODUCTION_CONFIG = {
   // API Configuration
   API_BASE_URL:
     import.meta.env.VITE_API_BASE_URL ||
-    "https://backend-vaxf.onrender.com/api",
+    "https://cleancare-pro-api-production-129e.up.railway.app/api",
 
   // Authentication
   AUTH_TOKEN_KEY: "laundrify_token",

--- a/src/integrations/mongodb/bookingHelpers.ts
+++ b/src/integrations/mongodb/bookingHelpers.ts
@@ -12,8 +12,8 @@ const getApiBaseUrl = () => {
     window.location.hostname.includes("vercel.app") ||
     window.location.hostname.includes("builder.codes")
   ) {
-    // Use the correct render.com backend URL
-    return "https://backend-vaxf.onrender.com/api";
+    // Use the correct Railway backend URL
+    return "https://cleancare-pro-api-production-129e.up.railway.app/api";
   }
 
   // For hosted environment, detect if we're on fly.dev and disable backend calls

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -12,7 +12,7 @@ export class ApiClient {
 
   constructor() {
     this.baseUrl =
-      import.meta.env.VITE_API_BASE_URL || "http://localhost:3001/api";
+      import.meta.env.VITE_API_BASE_URL || "https://cleancare-pro-api-production-129e.up.railway.app/api";
   }
 
   public static getInstance(): ApiClient {

--- a/src/services/dvhostingSmsService.ts
+++ b/src/services/dvhostingSmsService.ts
@@ -9,7 +9,7 @@ const getApiBaseUrl = () => {
     !hostname.includes("localhost") && !hostname.includes("127.0.0.1");
 
   if (isProduction) {
-    return "https://backend-vaxf.onrender.com/api";
+    return "https://cleancare-pro-api-production-129e.up.railway.app/api";
   }
 
   return "http://localhost:3001/api";
@@ -818,7 +818,7 @@ export class DVHostingSmsService {
           window.location.hostname.includes("vercel.app") ||
           window.location.hostname.includes("builder.codes")
         ) {
-          apiBaseUrl = "https://backend-vaxf.onrender.com/api";
+          apiBaseUrl = "https://cleancare-pro-api-production-129e.up.railway.app/api";
         } else {
           apiBaseUrl = "http://localhost:3001/api";
         }
@@ -903,7 +903,7 @@ export class DVHostingSmsService {
 
       if (!apiBaseUrl || apiBaseUrl === "") {
         if (window.location.hostname.includes("vercel.app")) {
-          apiBaseUrl = "https://backend-vaxf.onrender.com/api";
+          apiBaseUrl = "https://cleancare-pro-api-production-129e.up.railway.app/api";
         } else {
           apiBaseUrl = "http://localhost:3001/api";
         }


### PR DESCRIPTION
## Purpose
Update application configuration to use the new Railway deployment URLs as specified by the user. The frontend should point to "laundrify-up.up.railway.app" and the backend should point to "cleancare-pro-api-production-129e.up.railway.app".

## Code changes
- **Backend config**: Updated `ALLOWED_ORIGINS` in production.js to include the new Railway frontend URL
- **Service worker**: Added railway.app domain to the API request bypass list
- **Render config**: Updated environment variables to use Railway URLs for both frontend and backend
- **Production config**: Replaced old Render.com backend URLs with new Railway backend URL across multiple configuration files
- **API clients**: Updated default API base URLs in apiClient.ts, bookingHelpers.ts, and dvhostingSmsService.ts to point to the Railway backend
- **App branding**: Changed app name from "CleanCare Pro" to "Laundrify" in render.yaml

All hardcoded references to the old Render.com deployment URLs have been systematically replaced with the new Railway deployment endpoints.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/55b7e16ec4094ce48e1102c0586ddfb3/cosmos-world)

👀 [Preview Link](https://55b7e16ec4094ce48e1102c0586ddfb3-cosmos-world.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>55b7e16ec4094ce48e1102c0586ddfb3</projectId>-->
<!--<branchName>cosmos-world</branchName>-->