### PR TITLE
Fix modal z-index conflict preventing save address clicks

### DIFF
--- a/src/components/LocationUnavailableModal.tsx
+++ b/src/components/LocationUnavailableModal.tsx
@@ -52,7 +52,7 @@ const LocationUnavailableModal: React.FC<LocationUnavailableModalProps> = ({
   };
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-md w-[90vw] mx-auto border-0 shadow-2xl rounded-3xl overflow-hidden bg-white">
+      <DialogContent className="sm:max-w-md w-[90vw] mx-auto border-0 shadow-2xl rounded-3xl overflow-hidden bg-white z-[90]">
         {/* Close Button */}
         <button
           onClick={onClose}

--- a/src/components/LocationUnavailableModal.tsx
+++ b/src/components/LocationUnavailableModal.tsx
@@ -51,7 +51,8 @@ const LocationUnavailableModal: React.FC<LocationUnavailableModalProps> = ({
     onClose();
   };
   return (
-    <Dialog open={isOpen} onOpenChange={onClose}>
+    <div className="location-unavailable-modal">
+      <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="sm:max-w-md w-[90vw] mx-auto border-0 shadow-2xl rounded-3xl overflow-hidden bg-white z-[90]">
         {/* Close Button */}
         <button
@@ -120,7 +121,8 @@ const LocationUnavailableModal: React.FC<LocationUnavailableModalProps> = ({
           </div>
         </div>
       </DialogContent>
-    </Dialog>
+      </Dialog>
+    </div>
   );
 };
 

--- a/src/styles/mobile-fixes.css
+++ b/src/styles/mobile-fixes.css
@@ -191,6 +191,15 @@ html {
   z-index: 9999 !important;
 }
 
+/* Fix for LocationUnavailableModal z-index conflict with ZomatoAddAddressPage */
+.location-unavailable-modal [data-radix-dialog-overlay] {
+  z-index: 85 !important;
+}
+
+.location-unavailable-modal [data-radix-dialog-content] {
+  z-index: 90 !important;
+}
+
 /* Prevent body scroll when modal is open */
 .modal-open {
   overflow: hidden;


### PR DESCRIPTION
## Purpose
Fix a critical UI issue where the LocationUnavailableModal was not appearing when clicking "save address" for unavailable locations, causing page glitches and preventing user interactions. The user reported that no popup was showing and the page became unresponsive with blocked click functionality.

## Code changes
- **LocationUnavailableModal.tsx**: Added wrapper div with `location-unavailable-modal` class and increased z-index to `z-[90]` for the dialog content
- **mobile-fixes.css**: Added specific z-index rules for the modal overlay (85) and content (90) to resolve conflicts with ZomatoAddAddressPage
- Fixed modal layering hierarchy to ensure proper display and interaction

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 58`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d6db709d0f64435b8aa3dc6ac8442aef/aura-works)

👀 [Preview Link](https://d6db709d0f64435b8aa3dc6ac8442aef-aura-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d6db709d0f64435b8aa3dc6ac8442aef</projectId>-->
<!--<branchName>aura-works</branchName>-->