### PR TITLE
Fix CORS policy to allow all origins for development

### DIFF
--- a/backend/server-laundry.js
+++ b/backend/server-laundry.js
@@ -138,40 +138,10 @@ app.use("/api/auth", (req, res, next) => {
   next();
 });
 
-// CORS configuration - Enhanced for iOS Safari compatibility on mobile data
+// CORS configuration - Allow all origins for development
 app.use(
   cors({
-    origin: function (origin, callback) {
-      console.log(`🔍 CORS origin check: ${origin}`);
-
-      // Allow requests with no origin (like mobile apps or curl requests)
-      if (!origin) {
-        console.log('✅ CORS: Allowing request with no origin');
-        return callback(null, true);
-      }
-
-      // Check against allowed origins from config
-      if (productionConfig.ALLOWED_ORIGINS.indexOf(origin) !== -1) {
-        console.log('✅ CORS: Origin found in allowed origins list');
-        return callback(null, true);
-      }
-
-      // Special handling for Railway domains - more permissive for deployment
-      if (origin && (
-        origin.includes('railway.app') ||
-        origin.includes('railway.com') ||
-        origin.includes('laundrify-up.up.railway.app') ||
-        origin.includes('cleancare-pro-api-production-129e.up.railway.app') ||
-        origin.includes('localhost') ||
-        origin.includes('127.0.0.1')
-      )) {
-        console.log('✅ CORS: Allowing Railway/localhost domain');
-        return callback(null, true);
-      }
-
-      console.log(`❌ CORS: Origin ${origin} not allowed`);
-      return callback(new Error('Not allowed by CORS'));
-    },
+    origin: true, // Allow all origins
     credentials: true, // Enable credentials for iOS
     methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH", "HEAD"],
     allowedHeaders: [


### PR DESCRIPTION
## Purpose

The user was experiencing CORS errors when trying to send OTP requests from their frontend application. The error indicated that the API response was missing the 'Access-Control-Allow-Origin' header, preventing the frontend from accessing the API. The user requested to "allow all cors" to resolve this blocking issue.

## Code changes

- Simplified CORS configuration in `backend/server-laundry.js`
- Replaced complex origin validation logic with `origin: true` to allow all origins
- Removed the custom origin function that was checking against allowed origins list and Railway domain patterns
- Maintained existing settings for credentials, methods, and allowed headers
- Updated comment to reflect the new "allow all origins for development" approach

This change resolves the CORS blocking issue by permitting requests from any origin during development.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 82`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d29301e2386249fb8dfb90ddde5fa2a2/spark-sanctuary)

👀 [Preview Link](https://d29301e2386249fb8dfb90ddde5fa2a2-spark-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d29301e2386249fb8dfb90ddde5fa2a2</projectId>-->
<!--<branchName>spark-sanctuary</branchName>-->